### PR TITLE
code download  for number fields

### DIFF
--- a/lmfdb/ecnf/code.yaml
+++ b/lmfdb/ecnf/code.yaml
@@ -17,7 +17,7 @@ not-implemented:
     // (not yet implemented)
 
 field:
-  sage:  K.<a> = NumberField(%s)
+  sage: x = polygen(QQ);  K.<a> = NumberField(%s)
   pari: K = nfinit(%s);
   magma: R<x> := PolynomialRing(Rationals()); K<a> := NumberField(R!%s);
 

--- a/lmfdb/ecnf/main.py
+++ b/lmfdb/ecnf/main.py
@@ -748,8 +748,6 @@ def ecnf_code(**args):
     code += "{} (Note that not all these functions may be available, and some may take a long time to execute.)\n".format(Comment[lang])
     if lang=='gp':
         lang = 'pari'
-    if lang=='sage':
-        code += "\nx = polygen(QQ)\n"
     for k in sorted_code_names:
         if lang in Ecode[k]:
             code += "\n{} {}: \n".format(Comment[lang],code_names[k])

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -64,7 +64,7 @@ unit_group:
 unit_rank:
   sage:  UK.rank()
   pari:  |
-    #K.fu
+    K.fu
   magma: UnitRank(K);
 
 unit_torsion_gen:

--- a/lmfdb/number_fields/code.yaml
+++ b/lmfdb/number_fields/code.yaml
@@ -17,9 +17,9 @@ not-implemented:
     // (not yet implemented)
 
 field:
-  sage:  K = NumberField(%s,"a")
-  pari:  K = bnfinit(%s, 1)
-  magma: K<a> := NumberField(PolynomialRing(Rationals())!%s);
+  sage: x = polygen(QQ);  K.<a> = NumberField(%s)
+  pari: K = bnfinit(%s, 1)
+  magma: R<x> := PolynomialRing(Rationals()); K<a> := NumberField(R!%s);
 
 poly:
   sage:  K.defining_polynomial()


### PR DESCRIPTION
I did what you suggested, i.e. define x properly in the number field code snippets.  At the same time I added for number fields (in the Downloads section on the right which was not there before) a complete download of all code for the three languages.  I tested all three with a random number field on all three systems.  If you do the same and the field is not small you will ask whether we should add (for Magma) "SetClassGroupBounds("GRH");" and for Sage "proof.number_field('False')".